### PR TITLE
Adding a no loading when Folded option and pickup support.

### DIFF
--- a/UniversalAutoloadInstaller.lua
+++ b/UniversalAutoloadInstaller.lua
@@ -10,7 +10,7 @@ addModEventListener(UniversalAutoloadManager)
 g_specializationManager:addSpecialization('universalAutoload', 'UniversalAutoload', Utils.getFilename('UniversalAutoload.lua', g_currentModDirectory), true)
 
 for vehicleName, vehicleType in pairs(g_vehicleTypeManager.types) do
-	if vehicleName == 'trailer' or vehicleName == 'dynamicMountAttacherTrailer' then
+	if vehicleName == 'trailer' or vehicleName == 'dynamicMountAttacherTrailer' or vehicleName == 'carFillable' or vehicleName == 'car' then
 		if SpecializationUtil.hasSpecialization(TensionBelts, vehicleType.specializations) then
 			g_vehicleTypeManager:addSpecialization(vehicleName, 'universalAutoload')
 		end
@@ -87,6 +87,7 @@ function UniversalAutoload.ImportVehicleConfigurations(xmlFilename)
 			config.isCurtainTrailer = xmlFile:getValue(configKey..".options#isCurtainTrailer", false)
 			config.enableRearLoading = xmlFile:getValue(configKey..".options#enableRearLoading", false)
 			config.noLoadingIfUnfolded = xmlFile:getValue(configKey..".options#noLoadingIfUnfolded", false)
+			config.noLoadingIfFolded = xmlFile:getValue(configKey..".options#noLoadingIfFolded", false)
 			config.showDebug = xmlFile:getValue(configKey..".options#showDebug", false)
 			
 			print("  >> "..configFileName)

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -33,5 +33,13 @@
             <loadingArea offset="0 0.646 -0.895" width="2.00" height="2.00" length="4.32"/>
 			<options noLoadingIfUnfolded="true"/>
         </vehicleConfiguration>
+        <vehicleConfiguration configFileName="data/vehicles/lizard/pickup1986/pickup1986.xml">
+            <loadingArea offset="0 0.85 -1.50" width="1.25" height="1.25" length="3.10"/>
+			<options enableRearLoading="true" noLoadingIfFolded="true"/>
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="data/vehicles/lizard/pickup2017/pickup2017.xml">
+            <loadingArea offset="0 0.78 -1.72" width="1.25" height="1.25" length="3.10"/>
+			<options enableRearLoading="true" noLoadingIfFolded="true"/>
+        </vehicleConfiguration>
     </vehicleConfigurations>
 </universalAutoLoad>


### PR DESCRIPTION
This is more of a feature suggestion with some code than a true pull request. I was looking into what else I could add autoload to and started to investigate the pickups. Along with this, I added an option to only allow autoload when the trailer is unfolded. This allowed for a much bigger loading area on the pickup. 

But mainly, just wanted to show some edits I've been using on my save game. Figured if they worked others might like it.

Some examples. The first video shows the loading prompt missing until unfolded. Others are just some examples of the old pickup loading.

https://user-images.githubusercontent.com/15822357/155859433-e04df9bb-4dd8-47f1-9d24-4af90ebe78c8.mp4

https://user-images.githubusercontent.com/15822357/155859362-3f3cae31-6349-4bbf-8d01-96e61b45835b.mp4


https://user-images.githubusercontent.com/15822357/155859365-feb5e6d5-a367-4ca7-bec9-a9d4257f7bc2.mp4


https://user-images.githubusercontent.com/15822357/155859368-914e9a73-0b63-48c6-8a40-13bbbbf0fa82.mp4


One last thing I will note, loading via the rear trigger isn't working on the newer pickup for me. Still haven't figured out why. 