### PR TITLE
tweak: adjust Lode King Tri-Axle loading area

### DIFF
--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -18,7 +18,7 @@
 			<options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/lodeKing/renownTriAxleBeavertailLowDrop/renownTriAxleBeavertailLowDrop.xml">
-            <loadingArea offset="0 1.010 -1.0" width="2.40" height="2.60" length="11.1"/>
+            <loadingArea offset="0 1.010 -1.0" width="2.42" height="2.74" length="11.1"/>
 			<options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/krone/profiLiner/profiLiner.xml">


### PR DESCRIPTION
Minor adjustment to the Lode King's loading area to align with real-life
load capacity, 95,000 lbs. The drop-deck trailers should be able to
triple-stack 240cm bales as demonstrated in the below image.

![real-live triple-stacked bales](https://i.imgur.com/svy7Vlo.png)

In-game the bales are not at risk of falling off the trailer, and still
have a decent couple of inches on each side:

![in-game triple-stack](https://i.imgur.com/Ts3CjSY.jpg) 
![rear-view](https://i.imgur.com/AeUfSqG.jpg)
![rounds](https://i.imgur.com/FJW6qBz.jpg)

Cargo tested under this configuration:
 - 125cm round bales (32, 2x2x8)
 - 120cm bales (336, 2x24x7)
 - 240cm bales (36, 2x3x6)
 - Liquid fertilizer (7, 1x7)