### PR TITLE
feat: volume-based stacking logic

### DIFF
--- a/UniversalAutoload.lua
+++ b/UniversalAutoload.lua
@@ -2101,7 +2101,29 @@ function UniversalAutoload:getLoadPlace(containerType, object)
 		while spec.currentLoadLength < spec.loadArea.length do
 		
 			spec.currentLoadHeight = spec.currentLoadHeight or 0
-			if spec.currentLoadHeight + containerType.sizeY > spec.loadArea.height then
+
+			local containerVolume = containerType.sizeX * containerType.sizeY * containerType.sizeZ
+			local maxLoadAreaHeight = spec.loadArea.height
+			-- ignore volume if the loading area height is already small (no need to make smaller, would just cause issues)
+			if maxLoadAreaHeight > 1.5 then
+				-- container volume based placement logic
+				if containerVolume < 0.5 then
+					-- "tiny" volume container handling, can only be stacked to half maximum height
+					-- this includes 120cm square bales, empty pallets, silage additive, olive/sunflower/canola oil pallets, cake pallet, egg box pallet
+					maxLoadAreaHeight = spec.loadArea.height * 0.5
+				elseif containerVolume < 0.875 then
+					-- "small" volume container handling, can only be stacked to 2/3 maximum height
+					maxLoadAreaHeight = spec.loadArea.height * 0.67
+				elseif containerVolume < 1.25 then
+					-- "medium" volume container handling, can be stacked to 3/4 maximum height
+					-- smallest container in this category are boards pallets
+					-- largest container in this category is the patentkali fertilizer pallet ~1.21
+					maxLoadAreaHeight = spec.loadArea.height * 0.75
+				end
+				-- Anything larger than a "medium" volume container can be stacked to maximum height
+			end
+
+			if spec.currentLoadHeight + containerType.sizeY > maxLoadAreaHeight then
 				spec.makeNewLoadingPlace = true
 			end
 		

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -2,27 +2,27 @@
 <universalAutoLoad>
     <vehicleConfigurations>
         <vehicleConfiguration configFileName="data/vehicles/welger/dk115/dk115.xml" selectedConfigs="2">
-            <loadingArea offset="0 1.339 -0.165" width="1.95" height="2.00" length="4.525"/>
+            <loadingArea offset="0 1.339 -0.165" width="2.21" height="2.20" length="4.525"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/brantner/dd24073/dd24073.xml" selectedConfigs="1">
             <loadingArea offset="0 1.419 -0.75" width="2.41" height="2.80" length="7.25"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/fliegl/dts59/dts59.xml">
-            <loadingArea offset="0 1.205 -1.5" width="2.30" height="2.20" length="5.0"/>
+            <loadingArea offset="0 1.205 -1.5" width="2.40" height="2.40" length="5.0"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/bremerMaschinenbau/transportwagen/transportwagen.xml">
-            <loadingArea offset="0 0.515 -0.265" width="2.30" height="2.20" length="4.75"/>
+            <loadingArea offset="0 0.515 -0.265" width="2.40" height="2.40" length="4.75"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/demco/steelDropDeck/steelDropDeck.xml">
-            <loadingArea offset="0 1.010 -0.33" width="2.40" height="2.60" length="11.2"/>
+            <loadingArea offset="0 1.010 -0.33" width="2.40" height="2.74" length="11.2"/>
 			<options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/lodeKing/renownTriAxleBeavertailLowDrop/renownTriAxleBeavertailLowDrop.xml">
-            <loadingArea offset="0 1.010 -1.0" width="2.40" height="2.60" length="11.1"/>
+            <loadingArea offset="0 1.010 -1.0" width="2.42" height="2.74" length="11.1"/>
 			<options enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/krone/profiLiner/profiLiner.xml">
-            <loadingArea offset="0 1.185 -0.1" width="2.40" height="2.50" length="13.2"/>
+            <loadingArea offset="0 1.185 -0.1" width="2.40" height="2.74" length="13.2"/>
 			<options isCurtainTrailer="true" enableRearLoading="true" enableSideLoading="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/farmtech/dpw1800/dpw1800.xml">
@@ -32,7 +32,7 @@
             <loadingArea offset="0 1.275 -0.20" width="2.41" height="2.80" length="9.75"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/boeckmann/mhal4320/mhal4320.xml">
-            <loadingArea offset="0 0.650 -0.895" width="2.00" height="2.20" length="4.25"/>
+            <loadingArea offset="0 0.650 -0.895" width="2.00" height="2.43" length="4.25"/>
 			<options noLoadingIfUnfolded="true"/>
         </vehicleConfiguration>
         <vehicleConfiguration configFileName="data/vehicles/boeckmann/kk301827H/kk301827H.xml">
@@ -52,7 +52,7 @@
             <loadingArea offset="0 0.763 -1.370" width="1.05" height="2.20" length="2.25"/>
         </vehicleConfiguration>
 		<vehicleConfiguration configFileName="data/vehicles/johnDeere/xuv865M/xuv865M.xml">
-            <loadingArea offset="0 0.741 -0.99" width="1.30" height="1.00" length="1.05"/>
+            <loadingArea offset="0 0.741 -0.99" width="1.30" height="1.40" length="1.05"/>
         </vehicleConfiguration>
 		<vehicleConfiguration configFileName="data/vehicles/mahindra/retriever/retriever.xml">
             <loadingArea offset="0 0.777 -1.04" width="1.30" height="1.40" length="0.88"/>


### PR DESCRIPTION
Based on a discussion in #62, volume-based stacking logic limits the maximum current load height to different percentages of the actual maximum based on the volume of the container being stacked. This might make more sense as a density-based logic, but most containers weigh _close enough_ that this isn't necessary. This means that larger items, such as large square bales and bigger pallets can be stacked all the way to the vehicle's limits, but smaller items such as pallets of cake or small square bales are limited to a percentage of the maximum height. This allows stacking 240cm bales 3 high on most larger trailers, while still limiting smaller pallets and seed bags to a much smaller stack height.

I'm not 100% sure this is the best way to implement this, but it seems to be working fairly well - made some slight tweaks to some of the vehicles to allow similar-sized vehicles to stack items roughly the same.

![fully loaded](https://i.imgur.com/pOafGVU.jpg)