### PR TITLE
(Proposal) Add new `stackLimit` container config to allow specifying maximum depth of container

### DIFF
--- a/UniversalAutoload.lua
+++ b/UniversalAutoload.lua
@@ -106,6 +106,7 @@ function UniversalAutoload.initSpecialization()
 		s.schema:register(XMLValueType.BOOL, s.key.."#neverStack", "Should never load another pallet on top of this one when loading", false)
 		s.schema:register(XMLValueType.BOOL, s.key.."#neverRotate", "Should never rotate object when loading", false)
 		s.schema:register(XMLValueType.BOOL, s.key.."#alwaysRotate", "Should always rotate to face outwards for manual unloading", false)
+		s.schema:register(XMLValueType.INT, s.key.."#stackLimit", "Overrides the maximum number of layers to stack without regards to density", 0)
 	end
 
 	local schemaSavegame = Vehicle.xmlSchemaSavegame
@@ -2722,7 +2723,7 @@ function UniversalAutoload:getLoadPlace(containerType, object)
 						maxLoadAreaHeight = spec.loadArea[i].baleHeight
 					end
 					
-					if spec.currentLoadHeight > 0 and maxLoadAreaHeight > containerType.sizeY then
+					if spec.currentLoadHeight > 0 and maxLoadAreaHeight > containerType.sizeY and containerType.stackLimit == 0 then
 						local mass = UniversalAutoload.getContainerMass(object)
 						local volume = containerType.sizeX * containerType.sizeY * containerType.sizeZ
 						local density = mass/volume
@@ -2732,6 +2733,8 @@ function UniversalAutoload:getLoadPlace(containerType, object)
 						if maxLoadAreaHeight > 5*containerType.sizeY then
 							maxLoadAreaHeight = 5*containerType.sizeY
 						end
+					elseif containerType.stackLimit > 0 then
+						maxLoadAreaHeight = math.min(maxLoadAreaHeight, containerType.stackLimit * containerType.sizeY)
 					end
 
 					if spec.currentLoadHeight + containerType.sizeY > maxLoadAreaHeight then

--- a/UniversalAutoloadInstaller.lua
+++ b/UniversalAutoloadInstaller.lua
@@ -281,6 +281,7 @@ function UniversalAutoloadManager.ImportContainerTypeConfigurations(xmlFilename,
 					newType.neverStack = xmlFile:getValue(configKey.."#neverStack", default.neverStack or false)
 					newType.neverRotate = xmlFile:getValue(configKey.."#neverRotate", default.neverRotate or false)
 					newType.alwaysRotate = xmlFile:getValue(configKey.."#alwaysRotate", default.alwaysRotate or false)
+					newType.stackLimit = xmlFile:getValue(configKey.."#stackLimit", default.stackLimit or 0)
 					print(string.format("  >> %s %s [%.3f, %.3f, %.3f]", newType.type, newType.name, newType.sizeX, newType.sizeY, newType.sizeZ ))
 				end
 
@@ -334,6 +335,7 @@ function UniversalAutoloadManager.importContainerTypeFromXml(xmlFilename, custom
 				newType.neverStack = oldType.neverStack
 				newType.neverRotate = oldType.neverRotate
 				newType.alwaysRotate = oldType.alwaysRotate
+				newType.stackLimit = oldType.stackLimit
 
 				if oldType.isBale then
 					newType.width = oldType.width


### PR DESCRIPTION
This adds a new `stackLimit` option to the container config so that players can optionally override the density heuristic and customize how many layers high they are willing to stack each container type.

For example, the following specifies that planks pallets may be stacked up to 3 containers high.
```
<containerConfiguration containerType="EURO_PALLET" name="boardsStackPallet" stackLimit="3" />
```
Regardless of the stackLimit value, containers will still not be stacked higher than the dimensional constraints of the vehicle/trailer itself; this is merely a _maximum_ value. Setting the `stackLimit="0"` will result in the default behavior of using density to compute a maximum safe height.

