### PR TITLE
PDLC_forestryPack settings for UAL release

### DIFF
--- a/config/ContainerTypes.xml
+++ b/config/ContainerTypes.xml
@@ -62,6 +62,29 @@
 		<containerConfiguration containerType="POTATOBOX" name="FS22_Seedpotato_Farm_Pack:Potatoboxmedium"/>
 		<containerConfiguration containerType="POTATOBOX" name="FS22_Seedpotato_Farm_Pack:Potatoboxpremium"/>
 
+		<!-- Platinum DLC -->
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:armoirePallet" sizeX="2.42" sizeY="2.45" sizeZ="1.62" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:barrelPallet" sizeX="1.62" sizeY="1.04(p" sizeZ="1.22" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:bathtubPallet" sizeX="2.42" sizeY="0.7" sizeZ="0.84" neverStack="true" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:birdHousePallet" sizeX="1.24" sizeY="0.58" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:bowlsPallet" sizeX="1.24" sizeY="0.96" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:bucketPallet" sizeX="1.24" sizeY="0.77" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:cartonRollPallet" sizeX="2.42" sizeY="1.7" sizeZ="1.62" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:catTreePallet" sizeX="1.24" sizeY="0.98" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:chairPallet" sizeX="1.24" sizeY="1.28" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:dogHousePallet" sizeX="1.24" sizeY="1.1" sizeZ="0.86" neverStack="true" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:easelPallet" sizeX="1.24" sizeY="0.70" sizeZ="0.88" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:floorTilesPallet" sizeX="1.24" sizeY="0.82" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:metalPallet" sizeX="1.24" sizeY="0.9" sizeZ="0.84" neverStack="true" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:paperRollPallet" sizeX="2.42" sizeY="1.7" sizeZ="1.62" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:pepperGrinderPallet" sizeX="1.24" sizeY="1.0" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:pictureFramePallet" sizeX="1.24" sizeY="0.5" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:planksPallet" sizeX="2.5" sizeY="0.76" sizeZ="0.88" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:prefabWallPallet" sizeX="2.46" sizeY="2.64" sizeZ="1.76" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:shingleGenericPallet" sizeX="1.24" sizeY="1.36" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:staircaseRailingPallet" sizeX="1.24" sizeY="0.84" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:tablePallet" sizeX="2.42" sizeY="0.58" sizeZ="0.84" />
+        <containerConfiguration containerType="EURO_PALLET" name="pdlc_forestryPack:woodBeamPallet" sizeX="2.70" sizeY="0.94" sizeZ="0.92" />
     </containerConfigurations>
 </universalAutoload>
 

--- a/config/SupportedVehicles.xml
+++ b/config/SupportedVehicles.xml
@@ -158,5 +158,33 @@
 			<!-- <options isBaleTrailer="true"/> -->
         <!-- </vehicleConfiguration> -->
 
+        <!-- Platinum DLC --> 
+        <vehicleConfiguration configFileName="forestryPack/vehicles/volvo/sm462/sm462.xml">  
+            <loadingArea offset="0 0.9 -1.25" width="2.2" height="1.8" length="5.6"/>
+            <options isLogTrailer="true" enableRearLoading="true" enableSideLoading="false" showDebug="true" />
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="forestryPack/vehicles/schwarzmueller/timberTrailerSemi/timberTrailerSemi.xml">  
+            <loadingArea offset="0 1.5 0.4" width="2.3" height="3.0" length="13"/>
+            <options isLogTrailer="true" enableRearLoading="true" enableSideLoading="false" showDebug="true" />
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="forestryPack/vehicles/schwarzmueller/timberTrailer/timberTrailer.xml">  
+            <loadingArea offset="0 1.6 -0.1" width="2.2" height="3.0" length="8.1"/>
+            <options isLogTrailer="true" enableRearLoading="true" enableSideLoading="false" showDebug="true" />
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="forestryPack/vehicles/pfanzelt/rwgP13/rwgP13.xml" >  
+            <loadingArea offset="0 1.189 -1.65" width="1.7" height="2.0" length="5.1"/>
+            <options isLogTrailer="true" enableRearLoading="true" enableSideLoading="false" showDebug="true" />
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="forestryPack/vehicles/schwarzmueller/lowloader4A/lowloader4A.xml">  
+            <loadingArea offset="0 0.95 -2.4" width="2.8" height="2.4" length="6.2"/>
+            <loadingArea offset="0 1.2 2.1" width="2.8" height="2.4" length="2.3"/>
+            <options enableRearLoading="true" enableSideLoading="true" showDebug="true" />
+        </vehicleConfiguration>
+        <vehicleConfiguration configFileName="forestryPack/vehicles/schwarzmueller/semiLowloader3A/semiLowloader3A.xml">  
+            <loadingArea offset="0 0.9 -1.1" width="2.8" height="2.8" length="9.1"/>
+            <loadingArea offset="0 1.3 5.35" width="2.8" height="2.8" length="3.75"/>
+            <options enableRearLoading="true" enableSideLoading="true" showDebug="true" />
+        </vehicleConfiguration>
+
     </vehicleConfigurations>
 </universalAutoload>


### PR DESCRIPTION
- Added `isLogTrailer` configurations for all forestry related vehicles and trailers from DLC
- Added low loader configurations for two new low loaders.
- Added custom pallet configurations for all new pallet types.
   - Note: `BATHTUB`, `DOGHOUSE`, and `METAL` are all setup to `neverStack`